### PR TITLE
Added data array length check for infinite loading

### DIFF
--- a/src/components/Stories.js
+++ b/src/components/Stories.js
@@ -21,10 +21,11 @@ const Stories = props => {
   }, [props.storytype])
 
   const loadItems = (pageNumber) => {
+
     const pageItems = paginate(stories, pageNumber, 10) //10 items per page
     setrenderlist([...renderlist, ...pageItems.data])
     setinitialLoad(false)
-    sethasMoreItems(pageItems.currentPage !== pageItems.totalPages)
+    sethasMoreItems((pageItems.currentPage !== pageItems.totalPages) && pageItems.data.length !== 0)
   }
 
   if (!stories) {


### PR DESCRIPTION
I fixed issue #45 with this PR. 

What I did was adding one more condition to check if the loaded data is valid. 

This is what `sethasMoreItems `look like before. 

```
sethasMoreItems(pageItems.currentPage !== pageItems.totalPages)
```

And this is what it looks like now.

```
sethasMoreItems((pageItems.currentPage !== pageItems.totalPages) && pageItems.data.length !== 0)
```

This fixed the issue. So, please review it and let me know what you think. And if it resolves the issue, please accept the PR and let's close the issue. Thanks!